### PR TITLE
Fallback to $_SERVER variable on cli

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -23,20 +23,21 @@ namespace Platformsh\ConfigReader;
  * @property-read string $mode
  *   The hosting mode (this will only be set on Platform.sh Enterprise, and it
  *   will have the value 'enterprise').
- * @property-read array $application
+ * @property-read array  $application
  *   The application's configuration, as defined in the .platform.app.yaml file.
- * @property-read array $relationships
+ * @property-read array  $relationships
  *   The environment's relationships to other services. The keys are the name of
  *   the relationship (as configured for the application), and the values are a
  *   list of
- * @property-read array $routes
+ * @property-read array  $routes
  *   The routes configured for the environment.
- * @property-read array $variables
+ * @property-read array  $variables
  *   Custom environment variables.
  */
 class Config
 {
     protected $config = [];
+
     protected $environmentVariables = [];
 
     /**
@@ -58,7 +59,22 @@ class Config
      */
     public function __construct(array $environmentVariables = null)
     {
-        $this->environmentVariables = $environmentVariables ?: $_ENV;
+        $this->environmentVariables = $environmentVariables ?: $this->getDefaultEnvironment();
+    }
+
+    /**
+     * Returns the default environment. Falls back to the server array on cli usage, because $_ENV is empty then.
+     *
+     * @return array
+     */
+    protected function getDefaultEnvironment()
+    {
+        $env = $_ENV;
+        if (php_sapi_name() === 'cli' && 0 === count($env)) {
+            $env = $_SERVER;
+        }
+
+        return $env;
     }
 
     /**
@@ -77,7 +93,7 @@ class Config
         $result = json_decode(base64_decode($variable), true);
         if (json_last_error()) {
             throw new \Exception(
-                sprintf('Error decoding JSON, code: %d', json_last_error())
+              sprintf('Error decoding JSON, code: %d', json_last_error())
             );
         }
 
@@ -96,10 +112,10 @@ class Config
     protected function shouldDecode($variableName)
     {
         return in_array($variableName, [
-            'PLATFORM_APPLICATION',
-            'PLATFORM_RELATIONSHIPS',
-            'PLATFORM_ROUTES',
-            'PLATFORM_VARIABLES',
+          'PLATFORM_APPLICATION',
+          'PLATFORM_RELATIONSHIPS',
+          'PLATFORM_ROUTES',
+          'PLATFORM_VARIABLES',
         ]);
     }
 

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -6,33 +6,29 @@ use Platformsh\ConfigReader\Config;
 
 class ConfigTest extends \PHPUnit_Framework_TestCase
 {
+    private $mockEnv;
+
+    protected function setUp()
+    {
+        $this->mockEnv = [
+          'PLATFORM_PROJECT'       => 'test-project',
+          'PLATFORM_ENVIRONMENT'   => 'test-environment',
+          'PLATFORM_APPLICATION'   => $this->encode(['type' => 'php:7.0']),
+          'PLATFORM_RELATIONSHIPS' => $this->encode([
+            'database' => [0 => ['host' => '127.0.0.1']],
+          ]),
+          'PLATFORM_NEW'           => 'some-new-variable',
+        ];
+    }
+
     public function testConfig()
     {
         $config = new Config();
         $this->assertFalse($config->isAvailable());
 
-        $mockEnv = [
-            'PLATFORM_PROJECT' => 'test-project',
-            'PLATFORM_ENVIRONMENT' => 'test-environment',
-            'PLATFORM_APPLICATION' => $this->encode(['type' => 'php:7.0']),
-            'PLATFORM_RELATIONSHIPS' => $this->encode([
-                'database' => [0 => ['host' => '127.0.0.1']],
-            ]),
-            'PLATFORM_NEW' => 'some-new-variable',
-        ];
+        $config = new Config($this->mockEnv);
 
-        $config = new Config($mockEnv);
-
-        $this->assertTrue($config->isAvailable());
-        $this->assertEquals('php:7.0', $config->application['type']);
-        $this->assertEquals('test-project', $config->project);
-
-        $this->assertTrue(isset($config->relationships));
-        $this->assertTrue(isset($config->relationships['database'][0]));
-        $this->assertEquals('127.0.0.1', $config->relationships['database'][0]['host']);
-
-        /** @noinspection PhpUndefinedFieldInspection */
-        $this->assertEquals('some-new-variable', $config->new);
+        $this->assertMockEnv($config);
 
         $this->setExpectedException('Exception', 'not found');
         /** @noinspection PhpUndefinedFieldInspection */
@@ -42,12 +38,25 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
     public function testInvalidJson()
     {
         $config = new Config([
-            'PLATFORM_ENVIRONMENT' => 'test-environment',
-            'PLATFORM_VARIABLES' => base64_encode('{some-invalid-json}'),
+          'PLATFORM_ENVIRONMENT' => 'test-environment',
+          'PLATFORM_VARIABLES'   => base64_encode('{some-invalid-json}'),
         ]);
 
         $this->setExpectedException('Exception', 'Error decoding JSON');
         $config->variables;
+    }
+
+    public function testFallbackToServerVariable()
+    {
+        if (0 !== count($_ENV) || php_sapi_name() !== 'cli') {
+            self::markTestSkipped('Environment variable is not empty. Are you running this test via web?!');
+        }
+
+        $_SERVER = array_merge($_SERVER, $this->mockEnv);
+
+        $config = new Config();
+
+        $this->assertMockEnv($config);
     }
 
     /**
@@ -58,5 +67,22 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
     protected function encode($value)
     {
         return base64_encode(json_encode($value));
+    }
+
+    /**
+     * @param $config
+     */
+    protected function assertMockEnv(Config $config)
+    {
+        $this->assertTrue($config->isAvailable());
+        $this->assertEquals('php:7.0', $config->application['type']);
+        $this->assertEquals('test-project', $config->project);
+
+        $this->assertTrue(isset($config->relationships));
+        $this->assertTrue(isset($config->relationships['database'][0]));
+        $this->assertEquals('127.0.0.1', $config->relationships['database'][0]['host']);
+
+        /** @noinspection PhpUndefinedFieldInspection */
+        $this->assertEquals('some-new-variable', $config->new);
     }
 }


### PR DESCRIPTION
Fallback to $_SERVER variable on cli (e.g. when using doctrine migrations on Silex or something)

I have a silex app with a custom console to run doctrine-migrations on build:

``` yml
# The hooks that will be performed when the package is deployed.
hooks:
    # Build hooks can modify the application files on disk, but not access any services like databases.
    build: |
      php console.php migrations:migrate -n
      npm install
      bower install
```

I've noticed that the library didn't retrieved the environment variables, so I used the $_SERVER array as a fallback.
